### PR TITLE
Added check for header object properties that might be functions.

### DIFF
--- a/request-digest.es5.js
+++ b/request-digest.es5.js
@@ -201,6 +201,10 @@ var HTTPDigest = (function () {
         value: function _compileParams(params) {
             var parts = [];
             for (var i in params) {
+                if (typeof params[i] === 'function') {
+                  continue;
+                }
+
                 var param = i + '=' + (this._putDoubleQuotes(i) ? '"' : '') + params[i] + (this._putDoubleQuotes(i) ? '"' : '');
                 parts.push(param);
             }

--- a/request-digest.es6.js
+++ b/request-digest.es6.js
@@ -163,6 +163,10 @@ class HTTPDigest {
     _compileParams(params) {
         let parts = [];
         for (let i in params) {
+            if (typeof params[i] === 'function') {
+              continue;
+            }
+
             let param = i + '=' + (this._putDoubleQuotes(i) ? '"' : '') + params[i] + (this._putDoubleQuotes(i) ? '"' : '');
             parts.push(param);
         }

--- a/request-digest.js
+++ b/request-digest.js
@@ -130,7 +130,7 @@ var HTTPDigest = function () {
 
     if (typeof qop === 'string') {
       var cnonceHash = crypto.createHash('md5');
-      
+
       cnonceHash.update(Math.random().toString(36));
       cnonce = cnonceHash.digest('hex').substr(0, 8);
       nc = this._updateNC();
@@ -145,6 +145,10 @@ var HTTPDigest = function () {
   HTTPDigest.prototype._compileParams = function compileParams(params) {
     var parts = [];
     for (var i in params) {
+      if (typeof params[i] === 'function') {
+        continue;
+      }
+
       var param = i + '=' + (this._putDoubleQuotes(i) ? '"' : '') + params[i] + (this._putDoubleQuotes(i) ? '"' : '');
       parts.push(param);
     }
@@ -183,4 +187,3 @@ var HTTPDigest = function () {
 module.exports = function _createDigestClient(username, password) {
   return new HTTPDigest(username, password);
 };
-


### PR DESCRIPTION
If a function has been added to the Object prototype then it will appear in the list of keys being iterated over in _compileParams() method. Serializing a javascript function into the auth header is not only undesired, but will cause a TypeError exception to be thrown by the http module.