### PR TITLE
Header requires "algorithm=MD5"

### DIFF
--- a/request-digest.es6.js
+++ b/request-digest.es6.js
@@ -72,6 +72,7 @@ class HTTPDigest {
             nonce: challenge.nonce,
             uri: options.path,
             qop: challenge.qop,
+            algorithm: "MD5",
             opaque: challenge.opaque,
             response: response.digest('hex')
         };

--- a/request-digest.js
+++ b/request-digest.js
@@ -66,6 +66,7 @@ var HTTPDigest = function () {
       realm: challenge.realm,
       nonce: challenge.nonce,
       uri: options.path,
+      algorithm: "MD5",
       qop: challenge.qop,
       opaque: challenge.opaque,
       response: response.digest('hex'),


### PR DESCRIPTION
This adds the algorithm param to the header as needed in the spec. This can be hard coded because this library only supports MD5.